### PR TITLE
Make this actually compile again

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,10 +29,11 @@ SET(default_project_path "${CMAKE_SOURCE_DIR}/..")
 GET_FILENAME_COMPONENT(${default_project_path} ${default_project_path} REALPATH)
 
 SET(project_path "${default_project_path}" CACHE PATH "path to the other mo projects")
+SET(lib_path "${project_path}/../../install/libs")
 
 INCLUDE_DIRECTORIES(${project_path}/uibase/src
                     ${project_path}/game_features/src)
-LINK_DIRECTORIES(${project_path}/uibase/build/src)
+LINK_DIRECTORIES(${lib_path})
 
 
 ADD_LIBRARY(${PROJ_NAME} SHARED ${${PROJ_NAME}_HDRS} ${${PROJ_NAME}_SRCS} ${${PROJ_NAME}_UIHDRS} ${${PROJ_NAME}_translations_qm})


### PR DESCRIPTION
It looks like no one tested the recent switch to building with msbuild by default on a clean setup, because a bunch of projects are looking for libs in the old location. This fixes this project. More fixes are on the way as I discover more things which are broken.