### PR TITLE
Ignore all .user files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 edit
-CMakeLists.txt.user
+*.user
 /msbuild.log
 /*std*.log
 /*build


### PR DESCRIPTION
There are other user files (e.g. Qt project user files - .pro.user) that are currently picked up by git. Changing the .user blacklist for cmake to apply to all .user files