### PR TITLE
Fix error message when the info.xml file is invalid.

### DIFF
--- a/src/fomodinstallerdialog.cpp
+++ b/src/fomodinstallerdialog.cpp
@@ -259,7 +259,7 @@ void FomodInstallerDialog::readModuleConfigXml()
       }
     }
     if (!success) {
-      reportError(tr("Failed to parse ModuleConfig.xml. See console for details"));
+      reportError(tr("Failed to parse %1. See console for details.").arg("ModuleConfig.xml");
     }
 
     file.close();

--- a/src/fomodinstallerdialog.cpp
+++ b/src/fomodinstallerdialog.cpp
@@ -215,7 +215,7 @@ void FomodInstallerDialog::readInfoXml()
         }
       }
       if (!success) {
-        reportError(tr("Failed to parse ModuleConfig.xml. See console for details"));
+        reportError(tr("Failed to parse %1. See console for details.").arg("info.xml"));
       }
     }
     file.close();

--- a/src/installer_fomod_en.ts
+++ b/src/installer_fomod_en.ts
@@ -57,6 +57,7 @@
     </message>
     <message>
         <location filename="fomodinstallerdialog.cpp" line="218"/>
+        <location filename="fomodinstallerdialog.cpp" line="262"/>
         <source>Failed to parse %1. See console for details.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -66,8 +67,10 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="fomodinstallerdialog.cpp" line="218"/>
         <location filename="fomodinstallerdialog.cpp" line="262"/>
-        <source>Failed to parse ModuleConfig.xml. See console for details</source>
+        <source>Failed to parse %1. See console for details.</source>
+        <oldsource>Failed to parse ModuleConfig.xml. See console for details</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/installer_fomod_en.ts
+++ b/src/installer_fomod_en.ts
@@ -57,13 +57,17 @@
     </message>
     <message>
         <location filename="fomodinstallerdialog.cpp" line="218"/>
-        <location filename="fomodinstallerdialog.cpp" line="262"/>
-        <source>Failed to parse ModuleConfig.xml. See console for details</source>
+        <source>Failed to parse %1. See console for details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="fomodinstallerdialog.cpp" line="229"/>
         <source>ModuleConfig.xml missing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="fomodinstallerdialog.cpp" line="262"/>
+        <source>Failed to parse ModuleConfig.xml. See console for details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
Fix for https://github.com/ModOrganizer2/modorganizer/issues/1038