### PR TITLE
Ignore some missing folders when doing FOMOD installation.

### DIFF
--- a/src/fomodinstallerdialog.cpp
+++ b/src/fomodinstallerdialog.cpp
@@ -554,7 +554,7 @@ IPluginInstaller::EInstallResult FomodInstallerDialog::updateTree(std::shared_pt
   std::vector<const FileDescriptor*> failures;
 
   const QStringList ignoreMissingFolder = m_MoInfo->persistent(
-    m_Installer->name(), "ignore_missing_folders", QStringList{ "no folder" }).toStringList();
+    m_Installer->name(), "ignored_missing_files", QStringList{ "no folder" }).toStringList();
 
   for (const FileDescriptor *file : descriptorList) {
     if (!copyFileIterator(tree, newTree, file, leaves, overwrites)) {

--- a/src/fomodinstallerdialog.cpp
+++ b/src/fomodinstallerdialog.cpp
@@ -75,11 +75,10 @@ bool PagesDescending(QGroupBox *LHS, QGroupBox *RHS)
   return LHS->title() > RHS->title();
 }
 
-
-FomodInstallerDialog::FomodInstallerDialog(const GuessedValue<QString> &modName, const QString &fomodPath,
+FomodInstallerDialog::FomodInstallerDialog(InstallerFomod *installer, const GuessedValue<QString> &modName, const QString &fomodPath,
                                            const std::function<MOBase::IPluginList::PluginStates(const QString &)> &fileCheck,
                                            QWidget *parent)
-  : QDialog(parent), ui(new Ui::FomodInstallerDialog), m_ModName(modName), m_ModID(-1),
+  : QDialog(parent), ui(new Ui::FomodInstallerDialog), m_Installer(installer), m_ModName(modName), m_ModID(-1),
     m_FomodPath(fomodPath), m_Manual(false), m_FileCheck(fileCheck),
     m_FileSystemItemSequence()
 {
@@ -554,9 +553,14 @@ IPluginInstaller::EInstallResult FomodInstallerDialog::updateTree(std::shared_pt
 
   std::vector<const FileDescriptor*> failures;
 
+  const QStringList ignoreMissingFolder = m_MoInfo->persistent(
+    m_Installer->name(), "ignore_missing_folders", QStringList{ "no folder" }).toStringList();
+
   for (const FileDescriptor *file : descriptorList) {
     if (!copyFileIterator(tree, newTree, file, leaves, overwrites)) {
-      failures.push_back(file);
+      if (!ignoreMissingFolder.contains(file->m_Source, FileNameComparator::CaseSensitivity)) {
+        failures.push_back(file);
+      }
     }
   }
 

--- a/src/fomodinstallerdialog.h
+++ b/src/fomodinstallerdialog.h
@@ -22,6 +22,8 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include "guessedvalue.h"
 #include "ipluginlist.h"
 #include "iplugininstaller.h"
+#include "imoinfo.h"
+#include "ifiletree.h"
 
 #include <QDialog>
 #include <QGroupBox>
@@ -32,17 +34,13 @@ along with Mod Organizer.  If not, see <http://www.gnu.org/licenses/>.
 #include <functional>
 #include <vector>
 
-#include "ifiletree.h"
+#include "installerfomod.h"
 
 class QAbstractButton;
 class QXmlStreamReader;
 
 namespace Ui {
 class FomodInstallerDialog;
-}
-
-namespace MOBase {
- class IOrganizer;
 }
 
 class ValueCondition;
@@ -161,7 +159,8 @@ class FomodInstallerDialog : public QDialog, public IConditionTester
   Q_OBJECT
 
 public:
-  explicit FomodInstallerDialog(const MOBase::GuessedValue<QString> &modName,
+  explicit FomodInstallerDialog(InstallerFomod *installer,
+                                const MOBase::GuessedValue<QString> &modName,
                                 const QString &fomodPath,
                                 const std::function<MOBase::IPluginList::PluginStates (const QString &)> &fileCheck,
                                 QWidget *parent = 0);
@@ -384,6 +383,7 @@ private:
 
   Ui::FomodInstallerDialog *ui;
 
+  InstallerFomod* m_Installer;
   MOBase::GuessedValue<QString> m_ModName;
 
   int m_ModID;

--- a/src/installerfomod.cpp
+++ b/src/installerfomod.cpp
@@ -202,7 +202,7 @@ IPluginInstaller::EInstallResult InstallerFomod::install(GuessedValue<QString> &
           std::shared_ptr<const IFileTree> fomodTree = findFomodDirectory(tree);
 
           QString fomodPath = fomodTree->parent()->path();
-          FomodInstallerDialog dialog(modName, fomodPath, std::bind(&InstallerFomod::fileState, this, std::placeholders::_1));
+          FomodInstallerDialog dialog(this, modName, fomodPath, std::bind(&InstallerFomod::fileState, this, std::placeholders::_1));
           dialog.initData(m_MOInfo);
           if (!dialog.getVersion().isEmpty()) {
               version = dialog.getVersion();


### PR DESCRIPTION
Ignore some missing files and folders when doing FOMOD installation. This currently ignores only "no folder" since it seems to be commonly used by mods due to a bad FOMOD implementation in NMM.