### PR TITLE
WIP: Handle FOMODs installing relative to 'Root'

### DIFF
--- a/src/fomodinstallerdialog.h
+++ b/src/fomodinstallerdialog.h
@@ -275,11 +275,13 @@ private:
     PluginTypeInfo m_PluginTypeInfo;
     ConditionFlagList m_ConditionFlags;
     FileDescriptorList m_Files;
+    bool m_IsRoot{false};
   };
 
   struct ConditionalInstall {
     SubCondition m_Condition;
     FileDescriptorList m_Files;
+    bool m_IsRoot{false};
   };
 
   struct LeafInfo {
@@ -321,7 +323,7 @@ private:
   typedef void (FomodInstallerDialog::*TagProcessor)(XmlReader &reader);
   void processXmlTag(XmlReader &reader, char const *tag, TagProcessor func);
 
-  void readFileList(XmlReader &reader, FileDescriptorList &fileList);
+  void readFileList(XmlReader &reader, FileDescriptorList &fileList, bool& isBool);
   void readDependencyPattern(XmlReader &reader, DependencyPattern &pattern);
   void readDependencyPatternList(XmlReader &reader, DependencyPatternList &patterns);
   void readDependencyPluginType(XmlReader &reader, PluginTypeInfo &info);
@@ -390,6 +392,8 @@ private:
 
   QString m_FomodPath;
   bool m_Manual;
+  bool m_IsRoot;
+  bool m_IsRootConditional;
 
   FileDescriptorList m_RequiredFiles;
   std::vector<ConditionalInstall> m_ConditionalInstalls;


### PR DESCRIPTION
TODO: Make directories dynamic
TODO: Root directory should use user-settable

This is more of a proof of concept but makes a bunch of probably-not-ideal assumptions.

A) The 'Data' directory is always 'Data'.
B) The 'Data' directory is always inside the base game directory.
C) We always want to install 'Root' files to 'Root\'

For C I intend to add a setting to Workarounds to let users enable and define a directory to install 'root' files.

For A and B, we probably need to parse the actual defined game directories and calculate the true relative path between the 'Root' directory and the 'Data' directory. We can then pass those to the dialog and replace the current hardcoded search strings.